### PR TITLE
Improve performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,6 @@ matrix:
           env: SETUP_CMD='build_docs -w'
 
         # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.5
           env: ASTROPY_VERSION=development
         - python: 2.7

--- a/cextern/astrometry.net/healpix.c
+++ b/cextern/astrometry.net/healpix.c
@@ -161,6 +161,45 @@ void healpixl_decompose_ring(int64_t hp, int Nside, int* p_ring, int* p_longind)
 		*p_longind = (int)longind;
 }
 
+void healpixl_decompose_ring_closed(int64_t hp, int Nside, int* p_ring, int* p_longind) {
+	int64_t longind;
+	int64_t offset = 0;
+	int ring;
+	double x;
+
+	ring = (int)(0.5 + sqrt(0.25 + 0.5 * hp));
+	if (ring <= Nside) {
+		offset = 2 * ring * (ring - 1);
+		longind = hp - offset;
+		goto gotit;
+	} else {
+		offset = 2 * Nside * (Nside - 1);
+		ring = (int)((hp - offset) / (Nside * 4)) + Nside;
+		if (ring < 3 * Nside) {
+			offset += 4 * (ring - Nside) * Nside;
+			longind = hp - offset;
+			goto gotit;
+		} else {
+			 offset += 4 * (3 * Nside - Nside) * Nside;
+			 x = (2 * Nside + 1 - sqrt((2 * Nside + 1) * (2 * Nside + 1) - 2 * (hp - offset)))*0.5;
+			 ring = (int)x;
+			 offset += 2 * ring * (2 * Nside + 1 - ring);
+			 longind = (int)(hp - offset);
+			 ring += 3 * Nside;
+			 goto gotit;
+		}
+	}
+	fprintf(stderr, "healpix_decompose_ring: shouldn't get here!\n");
+	if (p_ring) *p_ring = -1;
+	if (p_longind) *p_longind = -1;
+	return;
+ gotit:
+	if (p_ring)
+		*p_ring = ring;
+	if (p_longind)
+		*p_longind = (int)longind;
+}
+
 Const int64_t healpixl_ring_to_xy(int64_t ring, int Nside) {
 	int bighp, x, y;
 	int ringind, longind;

--- a/cextern/astrometry.net/healpix.c
+++ b/cextern/astrometry.net/healpix.c
@@ -166,19 +166,16 @@ void healpixl_decompose_ring_closed(int64_t hp, int Nside, int* p_ring, int* p_l
 	int64_t offset = 0;
 	int ring;
 	double x;
-
 	ring = (int)(0.5 + sqrt(0.25 + 0.5 * hp));
 	if (ring <= Nside) {
 		offset = 2 * ring * (ring - 1);
 		longind = hp - offset;
-		goto gotit;
 	} else {
 		offset = 2 * Nside * (Nside - 1);
 		ring = (int)((hp - offset) / (Nside * 4)) + Nside;
 		if (ring < 3 * Nside) {
 			offset += 4 * (ring - Nside) * Nside;
 			longind = hp - offset;
-			goto gotit;
 		} else {
 			 offset += 4 * (3 * Nside - Nside) * Nside;
 			 x = (2 * Nside + 1 - sqrt((2 * Nside + 1) * (2 * Nside + 1) - 2 * (hp - offset)))*0.5;
@@ -186,14 +183,8 @@ void healpixl_decompose_ring_closed(int64_t hp, int Nside, int* p_ring, int* p_l
 			 offset += 2 * ring * (2 * Nside + 1 - ring);
 			 longind = (int)(hp - offset);
 			 ring += 3 * Nside;
-			 goto gotit;
 		}
 	}
-	fprintf(stderr, "healpix_decompose_ring: shouldn't get here!\n");
-	if (p_ring) *p_ring = -1;
-	if (p_longind) *p_longind = -1;
-	return;
- gotit:
 	if (p_ring)
 		*p_ring = ring;
 	if (p_longind)

--- a/cextern/astrometry.net/healpix.c
+++ b/cextern/astrometry.net/healpix.c
@@ -128,21 +128,23 @@ void healpixl_decompose_ring(int64_t hp, int Nside, int* p_ring, int* p_longind)
 	int64_t longind;
 	int64_t offset = 0;
 	int64_t Nside64;
+	int64_t ns2;
 	int ring;
 	double x;
 	Nside64 = (int64_t)Nside;
-	ring = (int)(0.5 + sqrt(0.25 + 0.5 * hp));
-	if (ring <= Nside) {
+	ns2 = Nside64 * Nside64;
+	if (hp < 2 * ns2) {
+		ring = (int)(0.5 + sqrt(0.25 + 0.5 * hp));
 		offset = 2 * ring * (ring - 1);
 		longind = hp - offset;
 	} else {
 		offset = 2 * Nside64 * (Nside64 - 1);
-		ring = (int)((hp - offset) / (Nside * 4)) + Nside;
-		if (ring < 3 * Nside) {
+		if (hp < 10 * ns2) {
+			ring = (int)((hp - offset) / (Nside * 4)) + Nside;
 			offset += 4 * (ring - Nside64) * Nside64;
 			longind = hp - offset;
 		} else {
-			 offset += 8 * Nside64 * Nside64;
+			 offset += 8 * ns2;
 			 x = (2 * Nside64 + 1 - sqrt((2 * Nside64 + 1) * (2 * Nside64 + 1) - 2 * (hp - offset)))*0.5;
 			 ring = (int)x;
 			 offset += 2 * ring * (2 * Nside64 + 1 - ring);

--- a/cextern/astrometry.net/healpix.c
+++ b/cextern/astrometry.net/healpix.c
@@ -125,43 +125,6 @@ Const int64_t healpixl_compose_ring(int64_t ring, int longind, int Nside) {
 }
 
 void healpixl_decompose_ring(int64_t hp, int Nside, int* p_ring, int* p_longind) {
-	// FIXME: this could be written in closed form...
-	int64_t longind;
-	int64_t offset = 0;
-	int ring;
-	for (ring=1; ring<=Nside; ring++) {
-		if (offset + ring*4 > hp) {
-			longind = hp - offset;
-			goto gotit;
-		}
-		offset += ring*4;
-	}
-	for (; ring<(3*Nside); ring++) {
-		if (offset + Nside*4 > hp) {
-			longind = hp - offset;
-			goto gotit;
-		}
-		offset += Nside*4;
-	}
-	for (; ring<(4*Nside); ring++) {
-		if (offset + (Nside*4 - ring)*4 > hp) {
-			longind = hp - offset;
-			goto gotit;
-		}
-		offset += (Nside*4 - ring)*4;
-	}
-	fprintf(stderr, "healpix_decompose_ring: shouldn't get here!\n");
-	if (p_ring) *p_ring = -1;
-	if (p_longind) *p_longind = -1;
-	return;
- gotit:
-	if (p_ring)
-		*p_ring = ring;
-	if (p_longind)
-		*p_longind = (int)longind;
-}
-
-void healpixl_decompose_ring_closed(int64_t hp, int Nside, int* p_ring, int* p_longind) {
 	int64_t longind;
 	int64_t offset = 0;
 	int ring;

--- a/cextern/astrometry.net/healpix.c
+++ b/cextern/astrometry.net/healpix.c
@@ -127,23 +127,25 @@ Const int64_t healpixl_compose_ring(int64_t ring, int longind, int Nside) {
 void healpixl_decompose_ring(int64_t hp, int Nside, int* p_ring, int* p_longind) {
 	int64_t longind;
 	int64_t offset = 0;
+	int64_t Nside64;
 	int ring;
 	double x;
+	Nside64 = (int64_t)Nside;
 	ring = (int)(0.5 + sqrt(0.25 + 0.5 * hp));
 	if (ring <= Nside) {
 		offset = 2 * ring * (ring - 1);
 		longind = hp - offset;
 	} else {
-		offset = 2 * Nside * (Nside - 1);
+		offset = 2 * Nside64 * (Nside64 - 1);
 		ring = (int)((hp - offset) / (Nside * 4)) + Nside;
 		if (ring < 3 * Nside) {
-			offset += 4 * (ring - Nside) * Nside;
+			offset += 4 * (ring - Nside64) * Nside64;
 			longind = hp - offset;
 		} else {
-			 offset += 4 * (3 * Nside - Nside) * Nside;
-			 x = (2 * Nside + 1 - sqrt((2 * Nside + 1) * (2 * Nside + 1) - 2 * (hp - offset)))*0.5;
+			 offset += 8 * Nside64 * Nside64;
+			 x = (2 * Nside64 + 1 - sqrt((2 * Nside64 + 1) * (2 * Nside64 + 1) - 2 * (hp - offset)))*0.5;
 			 ring = (int)x;
-			 offset += 2 * ring * (2 * Nside + 1 - ring);
+			 offset += 2 * ring * (2 * Nside64 + 1 - ring);
 			 longind = (int)(hp - offset);
 			 ring += 3 * Nside;
 		}

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -33,10 +33,34 @@ def _validate_offset(label, offset):
         raise ValueError('d{0} should be in the range [0:1]'.format(label))
 
 
+def _validate_level(level):
+    if level < 0:
+        raise ValueError('level should be positive')
+
+
 def _validate_nside(nside):
     log_2_nside = np.round(np.log2(nside))
     if not np.all(2 ** log_2_nside == nside):
         raise ValueError('nside should be a power of two')
+
+
+def level_to_nside(level):
+    """
+    Find the pixel dimensions of the top-level HEALPix tiles given the
+    resolution level (this is given by 2**level).
+
+    Parameters
+    ----------
+    level : int
+        The resolution level
+
+    Returns
+    -------
+    nside : int
+        The number of pixels on the side of one of the 12 'top-level' HEALPix tiles.
+    """
+    _validate_level(level)
+    return 2 ** level
 
 
 def nside_to_pixel_area(nside):

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -18,7 +18,7 @@ ORDER = {'nested': 0,
 
 
 def _validate_order(order):
-    if order not in ORDER:
+    if order.lower() not in ORDER:
         raise ValueError("order should be 'nested' or 'ring'")
 
 
@@ -190,13 +190,13 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
     _validate_order(order)
 
     if dx is None:
-        lon, lat = core_cython.healpix_to_lonlat(healpix_index, nside, ORDER[order])
+        lon, lat = core_cython.healpix_to_lonlat(healpix_index, nside, ORDER[order.lower()])
     else:
         dx = np.asarray(dx, dtype=np.float)
         dy = np.asarray(dy, dtype=np.float)
         _validate_offset('x', dx)
         _validate_offset('y', dy)
-        lon, lat = core_cython.healpix_with_offset_to_lonlat(healpix_index, dx, dy, nside, ORDER[order])
+        lon, lat = core_cython.healpix_with_offset_to_lonlat(healpix_index, dx, dy, nside, ORDER[order.lower()])
 
     lon = Longitude(lon, unit=u.rad, copy=False)
     lat = Latitude(lat, unit=u.rad, copy=False)
@@ -239,9 +239,9 @@ def lonlat_to_healpix(lon, lat, nside, return_offsets=False, order='ring'):
     _validate_order(order)
 
     if return_offsets:
-        return core_cython.lonlat_to_healpix_with_offset(lon, lat, nside, ORDER[order])
+        return core_cython.lonlat_to_healpix_with_offset(lon, lat, nside, ORDER[order.lower()])
     else:
-        return core_cython.lonlat_to_healpix(lon, lat, nside, ORDER[order])
+        return core_cython.lonlat_to_healpix(lon, lat, nside, ORDER[order.lower()])
 
 
 def nested_to_ring(nested_index, nside):
@@ -328,7 +328,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     if values.ndim != 1:
         raise ValueError("values should be a 1-dimensional array")
 
-    return core_cython.interpolate_bilinear_lonlat(lon, lat, values, ORDER[order])
+    return core_cython.interpolate_bilinear_lonlat(lon, lat, values, ORDER[order.lower()])
 
 
 def healpix_neighbors(healpix_index, nside, order='ring'):
@@ -358,7 +358,7 @@ def healpix_neighbors(healpix_index, nside, order='ring'):
     _validate_nside(nside)
     _validate_order(order)
 
-    return core_cython.healpix_neighbors(healpix_index, nside, ORDER[order])
+    return core_cython.healpix_neighbors(healpix_index, nside, ORDER[order.lower()])
 
 
 def healpix_cone_search(lon, lat, radius, nside, order='ring', approximate=False):
@@ -397,7 +397,7 @@ def healpix_cone_search(lon, lat, radius, nside, order='ring', approximate=False
     _validate_nside(nside)
     _validate_order(order)
 
-    return core_cython.healpix_cone_search(lon, lat, radius, nside, ORDER[order], approximate)
+    return core_cython.healpix_cone_search(lon, lat, radius, nside, ORDER[order.lower()], approximate)
 
 
 def boundaries_lonlat(healpix_index, step, nside, order='ring'):

--- a/healpix/core_cython.pyx
+++ b/healpix/core_cython.pyx
@@ -19,6 +19,7 @@ cdef int ORDER_NESTED = 0
 cdef int ORDER_RING = 1
 
 
+@cython.boundscheck(False)
 def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                       int nside, int order):
     """
@@ -57,8 +58,6 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     if order == ORDER_NESTED:
         for i in range(n):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
-            if xy_index < 0:
-                raise Exception("xy_index: " + str(xy_index))
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
     elif order == ORDER_RING:
         for i in range(n):

--- a/healpix/healpy.py
+++ b/healpix/healpy.py
@@ -42,7 +42,7 @@ def npix2nside(npix):
 
 
 def pix2ang(nside, ipix, nest=False):
-    ipix = np.atleast_1d(ipix).astype(np.int64)
+    ipix = np.atleast_1d(ipix).astype(np.int64, copy=False)
     lon, lat = healpix_to_lonlat(ipix, nside, 1 - int(nest))
     return np.pi / 2 - lat, lon
 

--- a/healpix/tests/test_core_cython.py
+++ b/healpix/tests/test_core_cython.py
@@ -27,7 +27,7 @@ def get_test_indices(nside):
         try:
             return np.random.randint(0, 12 * nside ** 2, 12 * 8 ** 2, dtype=np.int64)
         except TypeError:  # Numpy 1.9 and 1.10
-            return (np.random.random(12 * 8 ** 2) * (12 * float(nside) ** 2)).astype(np.int64)
+            return (np.random.random(12 * 8 ** 2) * (12 * float(nside) ** 2)).astype(np.int64, copy=False)
     else:
         return np.arange(12 * nside ** 2, dtype=np.int64)
 


### PR DESCRIPTION
This improves performance by a factor of a few for ring indexing by re-writing ``hp_decompose_ring`` in closed form (without loops). We are still 3-4x slower than healpy/HEALPIX for both ring and nested indexing.

EDIT: looks like the re-write isn't quite 64-bit int compatible yet.