### PR TITLE
Add docstrings to healpy interface functions

### DIFF
--- a/docs/healpy_compat.rst
+++ b/docs/healpy_compat.rst
@@ -7,6 +7,9 @@ a `healpy <http://healpy.readthedocs.io>`_-compatible interface in
 This is not the recommended interface, and is only provided as a convenience
 for packages that want to support both healpy and this package.
 
+Example
+-------
+
 As an example, the :func:`~healpix.healpy.pix2ang` function can be used to get
 the longitude/latitude of a given HEALPix pixel (by default using the 'ring'
 convention)::
@@ -20,3 +23,20 @@ which agrees exactly with the healpy function::
   >>> from healpy import pix2ang
   >>> pix2ang(16, [100, 120])
   (array([ 0.35914432,  0.41113786]), array([ 3.70259134,  1.6689711 ]))
+
+Migrate
+-------
+
+To migrate a script or package from using ``healpy`` to this ``healpix`` package,
+to check if the required functionality is available by changing all::
+
+    import healpy as hp
+
+to::
+
+    from healpix import healpy as hp
+
+and see what's missing or breaks. Please file issues or feature requests!
+
+As mentioned above, we then recommend that when you actually make the change,
+you use the main API of this package instead of the ``healpy``-compatible interface.

--- a/healpix/healpy.py
+++ b/healpix/healpy.py
@@ -16,11 +16,19 @@ from .core import (nside_to_pixel_resolution, nside_to_pixel_area,
 
 RAD2DEG = 180 / np.pi
 
-__all__ = ['nside2resol', 'nside2pixarea', 'nside2npix', 'npix2nside',
-           'pix2ang', 'ang2pix', 'order2nside']
+__all__ = [
+    'nside2resol',
+    'nside2pixarea',
+    'nside2npix',
+    'npix2nside',
+    'pix2ang',
+    'ang2pix',
+    'order2nside',
+]
 
 
 def nside2resol(nside, arcmin=False):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.nside2resol`."""
     resolution = nside_to_pixel_resolution(nside)
     if arcmin:
         return resolution.to(u.arcmin).value
@@ -29,6 +37,7 @@ def nside2resol(nside, arcmin=False):
 
 
 def nside2pixarea(nside, degrees=False):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.nside2pixarea`."""
     area = nside_to_pixel_area(nside)
     if degrees:
         return area.to(u.deg ** 2).value
@@ -37,18 +46,22 @@ def nside2pixarea(nside, degrees=False):
 
 
 def nside2npix(nside):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.nside2npix`."""
     return nside_to_npix(nside)
 
 
 def npix2nside(npix):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.npix2nside`."""
     return npix_to_nside(npix)
 
 
 def order2nside(order):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.order2nside`."""
     return level_to_nside(order)
 
 
 def pix2ang(nside, ipix, nest=False, lonlat=False):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.pix2ang`."""
     ipix = np.atleast_1d(ipix).astype(np.int64, copy=False)
     lon, lat = healpix_to_lonlat(ipix, nside, 1 - int(nest))
     # We use in-place operations below to avoid making temporary arrays - this
@@ -64,6 +77,7 @@ def pix2ang(nside, ipix, nest=False, lonlat=False):
 
 
 def ang2pix(nside, theta, phi, nest=False, lonlat=False):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.ang2pix`."""
     # Unlike in pix2ang, we don't use in-place operations since we don't
     # want to modify theta and phi since the user may be using them elsewhere.
     if lonlat:
@@ -74,10 +88,12 @@ def ang2pix(nside, theta, phi, nest=False, lonlat=False):
 
 
 def nest2ring(nside, ipix):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.nest2ring`."""
     ipix = np.atleast_1d(ipix).astype(np.int64, copy=False)
     return nested_to_ring(ipix, nside)
 
 
 def ring2nest(nside, ipix):
+    """Drop-in replacement for healpy `~healpy.pixelfunc.ring2nest`."""
     ipix = np.atleast_1d(ipix).astype(np.int64, copy=False)
     return ring_to_nested(ipix, nside)


### PR DESCRIPTION
This PR adds minimal docstrings to the functions in `healpix.healpy`, linking to the equivalent function in `healpy`. I think this is very useful, for quick checking if the functions really are equivalent in signature or not. Plus they have good docstrings, so no need to duplicate those in our docs.

I also added a `Migrate` section to the `healpy` docs page, that mentions that one can do the one-line import change to `from healpix import healpy to hp`.

@astrofrog - Please review.
