### PR TITLE
Improve order argument validation a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ distribute-*.tar.gz
 healpix/_compiler.c
 healpix/raw/wrap.c
 healpix/core_cython.c
+
+# pytest cache folder
+v

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -22,9 +22,12 @@ __all__ = [
 
 
 def _order_str_to_int(order):
-    if order == 'nested':
+    # We also support upper-case, to support directly the values
+    # ORDERING = {'RING', 'NESTED'} in FITS headers
+    # This is currently undocumented in the docstrings.
+    if order in {'nested', 'NESTED'}:
         return 0
-    elif order == 'ring':
+    elif order in {'ring', 'RING'}:
         return 1
     else:
         raise ValueError("order must be 'nested' or 'ring'")
@@ -33,23 +36,23 @@ def _order_str_to_int(order):
 def _validate_healpix_index(label, healpix_index, nside):
     npix = nside_to_npix(nside)
     if np.any((healpix_index < 0) | (healpix_index > npix - 1)):
-        raise ValueError('{0} should be in the range [0:{1}]'.format(label, npix))
+        raise ValueError('{0} must be in the range [0:{1}]'.format(label, npix))
 
 
 def _validate_offset(label, offset):
     if np.any((offset < 0) | (offset > 1)):
-        raise ValueError('d{0} should be in the range [0:1]'.format(label))
+        raise ValueError('d{0} must be in the range [0:1]'.format(label))
 
 
 def _validate_level(level):
     if level < 0:
-        raise ValueError('level should be positive')
+        raise ValueError('level must be positive')
 
 
 def _validate_nside(nside):
     log_2_nside = np.round(np.log2(nside))
     if not np.all(2 ** log_2_nside == nside):
-        raise ValueError('nside should be a power of two')
+        raise ValueError('nside must be a power of two')
 
 
 def level_to_nside(level):
@@ -151,7 +154,7 @@ def npix_to_nside(npix):
     npix = np.asanyarray(npix, dtype=np.int64)
 
     if not np.all(npix % 12 == 0):
-        raise ValueError('Number of pixels should be divisible by 12')
+        raise ValueError('Number of pixels must be divisible by 12')
 
     square_root = np.sqrt(npix / 12)
     if not np.all(square_root ** 2 == npix / 12):
@@ -174,7 +177,7 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
     dx, dy : `~numpy.ndarray`, optional
-        1-D arrays of offsets inside the HEALPix pixel, which should be in the
+        1-D arrays of offsets inside the HEALPix pixel, which must be in the
         range [0:1] (0.5 is the center of the HEALPix pixels)
     order : { 'nested' | 'ring' }, optional
         Order of HEALPix pixels
@@ -188,7 +191,7 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
     """
 
     if (dx is None and dy is not None) or (dx is not None and dy is None):
-        raise ValueError('Either both or neither dx and dy should be specified')
+        raise ValueError('Either both or neither dx and dy must be specified')
 
     healpix_index = np.asarray(healpix_index, dtype=np.int64)
     nside = int(nside)
@@ -316,7 +319,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
         The longitude and latitude values as :class:`~astropy.units.Quantity` instances
         with angle units.
     values : `~numpy.ndarray`
-        1-D array with the values in each HEALPix pixel. This should have a
+        1-D array with the values in each HEALPix pixel. This must have a
         length of the form 12 * nside ** 2 (and nside is determined
         automatically from this).
     order : { 'nested' | 'ring' }
@@ -336,7 +339,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
 
     # TODO: in future we could potentially support higher-dimensional arrays
     if values.ndim != 1:
-        raise ValueError("values should be a 1-dimensional array")
+        raise ValueError("values must be a 1-dimensional array")
 
     return core_cython.interpolate_bilinear_lonlat(lon, lat, values, order)
 
@@ -441,7 +444,7 @@ def boundaries_lonlat(healpix_index, step, nside, order='ring'):
     step = int(step)
 
     if step < 1:
-        raise ValueError('step should be at least 1')
+        raise ValueError('step must be at least 1')
 
     # PERF: this could be optimized by writing a Cython routine to do this to
     # avoid allocating temporary arrays

--- a/healpix/core_cython.pyx
+++ b/healpix/core_cython.pyx
@@ -64,7 +64,7 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
     else:
-        raise ValueError('order should be 0 or 1')
+        raise ValueError('order must be 0 or 1')
 
     return lon, lat
 
@@ -85,7 +85,7 @@ def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_
     healpix_index : `~numpy.ndarray`
         1-D array of HEALPix indices
     dx, dy : `~numpy.ndarray`
-        1-D arrays of offsets inside the HEALPix pixel, which should be in the
+        1-D arrays of offsets inside the HEALPix pixel, which must be in the
         range [0:1] (0.5 is the center of the HEALPix pixels)
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
@@ -114,7 +114,7 @@ def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
     else:
-        raise ValueError('order should be 0 or 1')
+        raise ValueError('order must be 0 or 1')
 
     return lon, lat
 
@@ -159,7 +159,7 @@ def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
     else:
-        raise ValueError('order should be 0 or 1')
+        raise ValueError('order must be 0 or 1')
 
     return healpix_index
 
@@ -208,7 +208,7 @@ def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
     else:
-        raise ValueError('order should be 0 or 1')
+        raise ValueError('order must be 0 or 1')
 
     return healpix_index, dx, dy
 
@@ -281,7 +281,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     lon, lat : `~numpy.ndarray`
         1-D arrays of longitude and latitude in radians
     values : `~numpy.ndarray`
-        1-D array with the values in each HEALPix pixel. This should have a
+        1-D array with the values in each HEALPix pixel. This must have a
         length of the form 12 * nside ** 2 (and nside is determined
         automatically from this).
     order : int
@@ -307,7 +307,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     cdef double square_root
 
     if npix % 12 != 0:
-        raise ValueError('Number of pixels should be divisible by 12')
+        raise ValueError('Number of pixels must be divisible by 12')
 
     square_root = (npix / 12.) ** 0.5
 
@@ -468,7 +468,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                     neighbours[j, i] = healpixl_xy_to_ring(neighbours_indiv[k], nside)
 
     else:
-        raise ValueError('order should be 0 or 1')
+        raise ValueError('order must be 0 or 1')
 
     return neighbours
 

--- a/healpix/high_level.py
+++ b/healpix/high_level.py
@@ -59,7 +59,7 @@ class HEALPix(object):
         healpix_index : `~numpy.ndarray`
             1-D array of HEALPix indices
         dx, dy : `~numpy.ndarray`, optional
-            1-D arrays of offsets inside the HEALPix pixel, which should be in
+            1-D arrays of offsets inside the HEALPix pixel, which must be in
             the range [0:1] (0.5 is the center of the HEALPix pixels). If not
             specified, the position at the center of the pixel is used.
 
@@ -142,7 +142,7 @@ class HEALPix(object):
             The longitude and latitude values as :class:`~astropy.units.Quantity` instances
             with angle units.
         values : `~numpy.ndarray`
-            1-D array with the values in each HEALPix pixel. This should have a
+            1-D array with the values in each HEALPix pixel. This must have a
             length of the form 12 * nside ** 2 (and nside is determined
             automatically from this).
 
@@ -152,7 +152,7 @@ class HEALPix(object):
             1-D array of interpolated values
         """
         if len(values) != self.npix:
-            raise ValueError('values should be an array of length {0} (got {1})'.format(self.npix, len(values)))
+            raise ValueError('values must be an array of length {0} (got {1})'.format(self.npix, len(values)))
         return interpolate_bilinear_lonlat(lon, lat, values, order=self.order)
 
     def cone_search_lonlat(self, lon, lat, radius, approximate=False):
@@ -179,7 +179,7 @@ class HEALPix(object):
             1-D array with all the matching HEALPix pixel indices.
         """
         if not lon.isscalar or not lat.isscalar or not radius.isscalar:
-            raise ValueError('The longitude, latitude and radius should be '
+            raise ValueError('The longitude, latitude and radius must be '
                              'scalar Quantity objects')
         return healpix_cone_search(lon, lat, radius, self.nside,
                                    order=self.order, approximate=approximate)
@@ -237,7 +237,7 @@ class CelestialHEALPix(HEALPix):
         healpix_index : `~numpy.ndarray`
             1-D array of HEALPix indices
         dx, dy : `~numpy.ndarray`, optional
-            1-D arrays of offsets inside the HEALPix pixel, which should be in
+            1-D arrays of offsets inside the HEALPix pixel, which must be in
             the range [0:1] (0.5 is the center of the HEALPix pixels). If not
             specified, the position at the center of the pixel is used.
 
@@ -288,7 +288,7 @@ class CelestialHEALPix(HEALPix):
         skycoord : :class:`~astropy.coordinates.SkyCoord`
             The celestial coordinates at which to interpolate
         values : `~numpy.ndarray`
-            1-D array with the values in each HEALPix pixel. This should have a
+            1-D array with the values in each HEALPix pixel. This must have a
             length of the form 12 * nside ** 2 (and nside is determined
             automatically from this).
 

--- a/healpix/tests/test_core.py
+++ b/healpix/tests/test_core.py
@@ -109,8 +109,8 @@ def test_healpix_to_lonlat_invalid():
     assert exc.value.args[0] == 'nside should be a power of two'
 
     with pytest.raises(ValueError) as exc:
-        lon, lat = healpix_to_lonlat([1, 2, 3], 4, order='banana')
-    assert exc.value.args[0] == "order should be 'nested' or 'ring'"
+        lon, lat = healpix_to_lonlat([1, 2, 3], 4, order='NESTED')
+    assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
     with pytest.raises(ValueError) as exc:
         lon, lat = healpix_to_lonlat([1, 2, 3], 4, dx=[-0.1, 0.4, 0.5], dy=dy)
@@ -140,7 +140,7 @@ def test_interpolate_bilinear_invalid():
     with pytest.raises(ValueError) as exc:
         interpolate_bilinear_lonlat([1, 3, 4] * u.deg, [3, 2, 6] * u.deg,
                                     values, order='banana')
-    assert exc.value.args[0] == "order should be 'nested' or 'ring'"
+    assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
 
 @pytest.mark.parametrize('order', ['nested', 'ring'])
@@ -183,7 +183,7 @@ def test_healpix_neighbors_invalid():
 
     with pytest.raises(ValueError) as exc:
         healpix_neighbors([1, 2, 3], 4, order='banana')
-    assert exc.value.args[0] == "order should be 'nested' or 'ring'"
+    assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
 
 @pytest.mark.parametrize('order', ['nested', 'ring'])

--- a/healpix/tests/test_core.py
+++ b/healpix/tests/test_core.py
@@ -21,7 +21,7 @@ def test_level_to_nside():
     assert level_to_nside(5) == 2 ** 5
     with pytest.raises(ValueError) as exc:
         level_to_nside(-1)
-    assert exc.value.args[0] == 'level should be positive'
+    assert exc.value.args[0] == 'level must be positive'
 
 
 def test_nside_to_pixel_area():
@@ -45,7 +45,7 @@ def test_nside_to_npix():
 
     with pytest.raises(ValueError) as exc:
         nside_to_npix(15)
-    assert exc.value.args[0] == 'nside should be a power of two'
+    assert exc.value.args[0] == 'nside must be a power of two'
 
 
 def test_npix_to_nside():
@@ -57,7 +57,7 @@ def test_npix_to_nside():
 
     with pytest.raises(ValueError) as exc:
         npix_to_nside(7)
-    assert exc.value.args[0] == 'Number of pixels should be divisible by 12'
+    assert exc.value.args[0] == 'Number of pixels must be divisible by 12'
 
     with pytest.raises(ValueError) as exc:
         npix_to_nside(12 * 8 * 9)
@@ -102,23 +102,23 @@ def test_healpix_to_lonlat_invalid():
 
     with pytest.raises(ValueError) as exc:
         lon, lat = healpix_to_lonlat([-1, 2, 3], 4)
-    assert exc.value.args[0] == 'healpix_index should be in the range [0:192]'
+    assert exc.value.args[0] == 'healpix_index must be in the range [0:192]'
 
     with pytest.raises(ValueError) as exc:
         lon, lat = healpix_to_lonlat([1, 2, 3], 5)
-    assert exc.value.args[0] == 'nside should be a power of two'
+    assert exc.value.args[0] == 'nside must be a power of two'
 
     with pytest.raises(ValueError) as exc:
-        lon, lat = healpix_to_lonlat([1, 2, 3], 4, order='NESTED')
+        lon, lat = healpix_to_lonlat([1, 2, 3], 4, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
 
     with pytest.raises(ValueError) as exc:
         lon, lat = healpix_to_lonlat([1, 2, 3], 4, dx=[-0.1, 0.4, 0.5], dy=dy)
-    assert exc.value.args[0] == 'dx should be in the range [0:1]'
+    assert exc.value.args[0] == 'dx must be in the range [0:1]'
 
     with pytest.raises(ValueError) as exc:
         lon, lat = healpix_to_lonlat([1, 2, 3], 4, dx=dx, dy=[-0.1, 0.4, 0.5])
-    assert exc.value.args[0] == 'dy should be in the range [0:1]'
+    assert exc.value.args[0] == 'dy must be in the range [0:1]'
 
 
 @pytest.mark.parametrize('order', ['nested', 'ring'])
@@ -134,7 +134,7 @@ def test_interpolate_bilinear_invalid():
     values = np.ones(133)
     with pytest.raises(ValueError) as exc:
         interpolate_bilinear_lonlat([1, 3, 4] * u.deg, [3, 2, 6] * u.deg, values)
-    assert exc.value.args[0] == 'Number of pixels should be divisible by 12'
+    assert exc.value.args[0] == 'Number of pixels must be divisible by 12'
 
     values = np.ones(192)
     with pytest.raises(ValueError) as exc:
@@ -175,11 +175,11 @@ def test_healpix_neighbors_invalid():
 
     with pytest.raises(ValueError) as exc:
         healpix_neighbors([-1, 2, 3], 4)
-    assert exc.value.args[0] == 'healpix_index should be in the range [0:192]'
+    assert exc.value.args[0] == 'healpix_index must be in the range [0:192]'
 
     with pytest.raises(ValueError) as exc:
         healpix_neighbors([1, 2, 3], 5)
-    assert exc.value.args[0] == 'nside should be a power of two'
+    assert exc.value.args[0] == 'nside must be a power of two'
 
     with pytest.raises(ValueError) as exc:
         healpix_neighbors([1, 2, 3], 4, order='banana')

--- a/healpix/tests/test_high_level.py
+++ b/healpix/tests/test_high_level.py
@@ -73,7 +73,7 @@ class TestHEALPix:
         with pytest.raises(ValueError) as exc:
             self.pix.interpolate_bilinear_lonlat([1, 3, 4] * u.deg,
                                                  [3, 2, 6] * u.deg, values)
-        assert exc.value.args[0] == 'values should be an array of length 786432 (got 222)'
+        assert exc.value.args[0] == 'values must be an array of length 786432 (got 222)'
 
     def test_cone_search_lonlat(self):
         lon, lat = 1 * u.deg, 4 * u.deg
@@ -84,7 +84,7 @@ class TestHEALPix:
         lon, lat = [1, 2] * u.deg, [3, 4] * u.deg
         with pytest.raises(ValueError) as exc:
             self.pix.cone_search_lonlat(lon, lat, 1 * u.deg)
-        assert exc.value.args[0] == 'The longitude, latitude and radius should be scalar Quantity objects'
+        assert exc.value.args[0] == 'The longitude, latitude and radius must be scalar Quantity objects'
 
     def test_boundaries_lonlat(self):
         lon, lat = self.pix.boundaries_lonlat([10, 20, 30], 4)

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     scripts=scripts,
-    install_requires=['astropy'],
+    install_requires=['numpy', 'astropy'],
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
     license=LICENSE,


### PR DESCRIPTION
This PR improves argument validation for `order` a little bit, avoiding the many duplications of `ORDER[order.lower()]`.

I also changed the language from "should" to "must" in the errors, and would suggest to do this change for all the errors in this PR. @astrofrog - OK?

The main question here I think is whether we should call `.lower` and support `order='RING'` in addition to `order='ring'`? On the one hand I think being strict it better, because it means that there's one way to do it instead of a few and all scripts calling this will look the same. On the other hand, there might be a reason to support multiple capitalisations here? If there isn't a strong one, I'm +1 to be strict.

@astrofrog - Thoughts?