### PR TITLE
Bug in cone_search_skycoord

### DIFF
--- a/healpix/high_level.py
+++ b/healpix/high_level.py
@@ -328,7 +328,7 @@ class CelestialHEALPix(HEALPix):
         skycoord = skycoord.transform_to(self.frame)
         representation = skycoord.represent_as(UnitSphericalRepresentation)
         lon, lat = representation.lon, representation.lat
-        return self.cone_search_lonlat(lon, lat, radius, self.nside)
+        return self.cone_search_lonlat(lon, lat, radius, approximate=approximate)
 
     def boundaries_skycoord(self, healpix_index, step):
         """


### PR DESCRIPTION
@astrofrog - Here you're passing as forth argument `self.nside`, but I think it should be `approximate`, no?
https://github.com/cdeil/healpix/blob/a3cfdef81ee9d82c650ca9982cfd60897f2c12b7/healpix/high_level.py#L331

Would it be easy for you to fix and add a test case or should I do it?