### PR TITLE
Preserve shape of arrays in core Python functions

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,6 +16,8 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python -c 'import sys; print(sys.maxsize)'
 
+pip install six
+
 # We only test the docs output on 64-bit Linux so as not to have to 
 # degrade the output with ellipses to work on all platforms.
 python setup.py test -V -a "-s" --skip-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython healpy>1.10 hypothesis'
+        - CONDA_DEPENDENCIES='Cython healpy>1.10 hypothesis six'
 
         # Conda packages for affiliated packages are hosted in channel
         # "astropy" while builds for astropy LTS with recent numpy versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
 
-      CONDA_DEPENDENCIES: "Cython numpy"
+      CONDA_DEPENDENCIES: "Cython numpy six"
 
   matrix:
 

--- a/docs/cone_search.rst
+++ b/docs/cone_search.rst
@@ -30,6 +30,4 @@ specific celestial coordinates::
     >>> from astropy.coordinates import SkyCoord
     >>> coord = SkyCoord('00h42m44.3503s +41d16m08.634s')
     >>> hp.cone_search_skycoord(coord, radius=5 * u.arcmin)
-    array([2537, 2540, 2542, 2539, 2538, 2536, 2530, 2531, 2534, 2535, 2541,
-           2529, 2532, 2507, 2528, 2506, 2485, 2487, 2486, 2493, 2492, 2495,
-           1344, 1345, 2543])
+    array([2537])

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -99,7 +99,7 @@ and to convert from celestial coordinates to HEALPix indices you can use the
     >>> from astropy.coordinates import SkyCoord
     >>> coord = SkyCoord('00h42m44.3503s +41d16m08.634s')
     >>> hp.skycoord_to_healpix(coord)
-    array([2537])
+    2537
 
 Converting between ring and nested conventions
 ----------------------------------------------

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -21,6 +21,20 @@ __all__ = [
 ]
 
 
+def _restore_shape(*args, **kwargs):
+    shape = kwargs['shape']
+    if shape:
+        if len(args) > 1:
+            return [arg.reshape(shape) for arg in args]
+        else:
+            return args[0].reshape(shape)
+    else:
+        if len(args) > 1:
+            return [np.asscalar(arg) for arg in args]
+        else:
+            return np.asscalar(args[0])
+
+
 def _order_str_to_int(order):
     # We also support upper-case, to support directly the values
     # ORDERING = {'RING', 'NESTED'} in FITS headers
@@ -172,13 +186,13 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
 
     Parameters
     ----------
-    healpix_index : `~numpy.ndarray`
-        1-D array of HEALPix indices
+    healpix_index : int or `~numpy.ndarray`
+        HEALPix indices (as a scalar or array)
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    dx, dy : `~numpy.ndarray`, optional
-        1-D arrays of offsets inside the HEALPix pixel, which must be in the
-        range [0:1] (0.5 is the center of the HEALPix pixels)
+    dx, dy : float or `~numpy.ndarray`, optional
+        Offsets inside the HEALPix pixel, which must be in the range [0:1],
+        where 0.5 is the center of the HEALPix pixels (as scalars or arrays)
     order : { 'nested' | 'ring' }, optional
         Order of HEALPix pixels
 
@@ -194,6 +208,23 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
         raise ValueError('Either both or neither dx and dy must be specified')
 
     healpix_index = np.asarray(healpix_index, dtype=np.int64)
+
+    if dx is None and dy is not None:
+        dx = 0.5
+    elif dx is not None and dy is None:
+        dy = 0.5
+
+    if dx is not None:
+        dx = np.asarray(dx, dtype=np.float)
+        dy = np.asarray(dy, dtype=np.float)
+        _validate_offset('x', dx)
+        _validate_offset('y', dy)
+        healpix_index, dx, dy = np.broadcast_arrays(healpix_index, dx, dy)
+        dx = dx.ravel()
+        dy = dy.ravel()
+
+    shape = healpix_index.shape
+    healpix_index = healpix_index.ravel()
     nside = int(nside)
 
     _validate_healpix_index('healpix_index', healpix_index, nside)
@@ -203,16 +234,12 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
     if dx is None:
         lon, lat = core_cython.healpix_to_lonlat(healpix_index, nside, order)
     else:
-        dx = np.asarray(dx, dtype=np.float)
-        dy = np.asarray(dy, dtype=np.float)
-        _validate_offset('x', dx)
-        _validate_offset('y', dy)
         lon, lat = core_cython.healpix_with_offset_to_lonlat(healpix_index, dx, dy, nside, order)
 
     lon = Longitude(lon, unit=u.rad, copy=False)
     lat = Latitude(lat, unit=u.rad, copy=False)
 
-    return lon, lat
+    return _restore_shape(lon, lat, shape=shape)
 
 
 def lonlat_to_healpix(lon, lat, nside, return_offsets=False, order='ring'):
@@ -222,8 +249,8 @@ def lonlat_to_healpix(lon, lat, nside, return_offsets=False, order='ring'):
     Parameters
     ----------
     lon, lat : :class:`~astropy.units.Quantity`
-        The longitude and latitude values as :class:`~astropy.units.Quantity` instances
-        with angle units.
+        The longitude and latitude values as :class:`~astropy.units.Quantity`
+        instances with angle units.
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
     order : { 'nested' | 'ring' }
@@ -235,24 +262,33 @@ def lonlat_to_healpix(lon, lat, nside, return_offsets=False, order='ring'):
 
     Returns
     -------
-    healpix_index : `~numpy.ndarray`
-        1-D array of HEALPix indices
+    healpix_index : int or `~numpy.ndarray`
+        The HEALPix indices
     dx, dy : `~numpy.ndarray`
-        1-D arrays of offsets inside the HEALPix pixel in the range [0:1] (0.5
-        is the center of the HEALPix pixels)
+        Offsets inside the HEALPix pixel in the range [0:1], where 0.5 is the
+        center of the HEALPix pixels
     """
 
-    lon = np.atleast_1d(lon.to(u.rad).value).astype(np.float)
-    lat = np.atleast_1d(lat.to(u.rad).value).astype(np.float)
-    nside = int(nside)
+    lon = lon.to(u.rad).value
+    lat = lat.to(u.rad).value
 
+    lon, lat = np.broadcast_arrays(lon, lat)
+
+    shape = np.shape(lon)
+
+    lon = lon.astype(float).ravel()
+    lat = lat.astype(float).ravel()
+
+    nside = int(nside)
     _validate_nside(nside)
     order = _order_str_to_int(order)
 
     if return_offsets:
-        return core_cython.lonlat_to_healpix_with_offset(lon, lat, nside, order)
+        healpix_index, dx, dy = core_cython.lonlat_to_healpix_with_offset(lon, lat, nside, order)
+        return _restore_shape(healpix_index, dx, dy, shape=shape)
     else:
-        return core_cython.lonlat_to_healpix(lon, lat, nside, order)
+        healpix_index = core_cython.lonlat_to_healpix(lon, lat, nside, order)
+        return _restore_shape(healpix_index, shape=shape)
 
 
 def nested_to_ring(nested_index, nside):
@@ -261,24 +297,26 @@ def nested_to_ring(nested_index, nside):
 
     Parameters
     ----------
-    nested_index : `~numpy.ndarray`
+    nested_index : int or `~numpy.ndarray`
         Healpix index using the 'nested' ordering
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
 
     Returns
     -------
-    ring_index : `~numpy.ndarray`
+    ring_index : int or `~numpy.ndarray`
         Healpix index using the 'ring' ordering
     """
 
-    nested_index = np.atleast_1d(np.asarray(nested_index, dtype=np.int64))
+    nested_index = np.asarray(nested_index, dtype=np.int64)
+    shape = nested_index.shape
+    nested_index = nested_index.ravel()
     nside = int(nside)
 
     _validate_healpix_index('nested_index', nested_index, nside)
     _validate_nside(nside)
 
-    return core_cython.nested_to_ring(nested_index, nside)
+    return _restore_shape(core_cython.nested_to_ring(nested_index, nside), shape=shape)
 
 
 def ring_to_nested(ring_index, nside):
@@ -287,24 +325,26 @@ def ring_to_nested(ring_index, nside):
 
     Parameters
     ----------
-    ring_index : `~numpy.ndarray`
+    ring_index : int or `~numpy.ndarray`
         Healpix index using the 'ring' ordering
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
 
     Returns
     -------
-    nested_index : `~numpy.ndarray`
+    nested_index : int or `~numpy.ndarray`
         Healpix index using the 'nested' ordering
     """
 
-    ring_index = np.atleast_1d(np.asarray(ring_index, dtype=np.int64))
+    ring_index = np.asarray(ring_index, dtype=np.int64)
+    shape = ring_index.shape
+    ring_index = ring_index.ravel()
     nside = int(nside)
 
     _validate_healpix_index('ring_index', ring_index, nside)
     _validate_nside(nside)
 
-    return core_cython.ring_to_nested(ring_index, nside)
+    return _restore_shape(core_cython.ring_to_nested(ring_index, nside), shape=shape)
 
 
 def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
@@ -327,12 +367,20 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
 
     Returns
     -------
-    result : `~numpy.ndarray`
-        1-D array of interpolated values
+    result : float `~numpy.ndarray`
+        The interpolated values
     """
 
-    lon = np.atleast_1d(lon.to(u.rad).value).astype(np.float)
-    lat = np.atleast_1d(lat.to(u.rad).value).astype(np.float)
+    lon = lon.to(u.rad).value
+    lat = lat.to(u.rad).value
+
+    lon, lat = np.broadcast_arrays(lon, lat)
+
+    shape = np.shape(lon)
+
+    lon = lon.astype(float).ravel()
+    lat = lat.astype(float).ravel()
+
     values = np.asarray(values, dtype=float)
 
     order = _order_str_to_int(order)
@@ -341,7 +389,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     if values.ndim != 1:
         raise ValueError("values must be a 1-dimensional array")
 
-    return core_cython.interpolate_bilinear_lonlat(lon, lat, values, order)
+    return _restore_shape(core_cython.interpolate_bilinear_lonlat(lon, lat, values, order), shape=shape)
 
 
 def healpix_neighbors(healpix_index, nside, order='ring'):

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -35,14 +35,14 @@ def _restore_shape(*args, **kwargs):
             return np.asscalar(args[0])
 
 
-def _order_str_to_int(order):
+def _validate_order(order):
     # We also support upper-case, to support directly the values
     # ORDERING = {'RING', 'NESTED'} in FITS headers
     # This is currently undocumented in the docstrings.
     if order in {'nested', 'NESTED'}:
-        return 0
+        return 'nested'
     elif order in {'ring', 'RING'}:
-        return 1
+        return 'ring'
     else:
         raise ValueError("order must be 'nested' or 'ring'")
 
@@ -229,7 +229,7 @@ def healpix_to_lonlat(healpix_index, nside, dx=None, dy=None, order='ring'):
 
     _validate_healpix_index('healpix_index', healpix_index, nside)
     _validate_nside(nside)
-    order = _order_str_to_int(order)
+    order = _validate_order(order)
 
     if dx is None:
         lon, lat = core_cython.healpix_to_lonlat(healpix_index, nside, order)
@@ -281,7 +281,7 @@ def lonlat_to_healpix(lon, lat, nside, return_offsets=False, order='ring'):
 
     nside = int(nside)
     _validate_nside(nside)
-    order = _order_str_to_int(order)
+    order = _validate_order(order)
 
     if return_offsets:
         healpix_index, dx, dy = core_cython.lonlat_to_healpix_with_offset(lon, lat, nside, order)
@@ -385,7 +385,7 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
 
     values = np.asarray(values, dtype=float)
 
-    order = _order_str_to_int(order)
+    order = _validate_order(order)
 
     # TODO: in future we could potentially support higher-dimensional arrays
     if values.ndim != 1:
@@ -420,7 +420,7 @@ def healpix_neighbors(healpix_index, nside, order='ring'):
 
     _validate_healpix_index('healpix_index', healpix_index, nside)
     _validate_nside(nside)
-    order = _order_str_to_int(order)
+    order = _validate_order(order)
 
     return core_cython.healpix_neighbors(healpix_index, nside, order)
 
@@ -459,7 +459,7 @@ def healpix_cone_search(lon, lat, radius, nside, order='ring', approximate=False
     approximate = int(approximate)
 
     _validate_nside(nside)
-    order = _order_str_to_int(order)
+    order = _validate_order(order)
 
     return core_cython.healpix_cone_search(lon, lat, radius, nside, order, approximate)
 

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -8,6 +8,7 @@ from astropy import units as u
 from astropy.coordinates import Longitude, Latitude
 
 from . import core_cython
+from .core_cython import _validate_order
 
 __all__ = [
     'nside_to_pixel_area',
@@ -33,18 +34,6 @@ def _restore_shape(*args, **kwargs):
             return [np.asscalar(arg) for arg in args]
         else:
             return np.asscalar(args[0])
-
-
-def _validate_order(order):
-    # We also support upper-case, to support directly the values
-    # ORDERING = {'RING', 'NESTED'} in FITS headers
-    # This is currently undocumented in the docstrings.
-    if order in {'nested', 'NESTED'}:
-        return 'nested'
-    elif order in {'ring', 'RING'}:
-        return 'ring'
-    else:
-        raise ValueError("order must be 'nested' or 'ring'")
 
 
 def _validate_healpix_index(label, healpix_index, nside):

--- a/healpix/core.py
+++ b/healpix/core.py
@@ -316,7 +316,8 @@ def nested_to_ring(nested_index, nside):
     _validate_healpix_index('nested_index', nested_index, nside)
     _validate_nside(nside)
 
-    return _restore_shape(core_cython.nested_to_ring(nested_index, nside), shape=shape)
+    ring_index = core_cython.nested_to_ring(nested_index, nside)
+    return _restore_shape(ring_index, shape=shape)
 
 
 def ring_to_nested(ring_index, nside):
@@ -344,7 +345,8 @@ def ring_to_nested(ring_index, nside):
     _validate_healpix_index('ring_index', ring_index, nside)
     _validate_nside(nside)
 
-    return _restore_shape(core_cython.ring_to_nested(ring_index, nside), shape=shape)
+    nested_index = core_cython.ring_to_nested(ring_index, nside)
+    return _restore_shape(nested_index, shape=shape)
 
 
 def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
@@ -389,7 +391,8 @@ def interpolate_bilinear_lonlat(lon, lat, values, order='ring'):
     if values.ndim != 1:
         raise ValueError("values must be a 1-dimensional array")
 
-    return _restore_shape(core_cython.interpolate_bilinear_lonlat(lon, lat, values, order), shape=shape)
+    result = core_cython.interpolate_bilinear_lonlat(lon, lat, values, order)
+    return _restore_shape(result, shape=shape)
 
 
 def healpix_neighbors(healpix_index, nside, order='ring'):

--- a/healpix/core_cython.pyx
+++ b/healpix/core_cython.pyx
@@ -15,13 +15,10 @@ npy_double = np.double
 npy_intp = np.intp
 npy_int64 = np.int64
 
-cdef int ORDER_NESTED = 0
-cdef int ORDER_RING = 1
-
 
 @cython.boundscheck(False)
 def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
-                      int nside, int order):
+                      int nside, str order):
     """
     Convert HEALPix indices to longitudes/latitudes.
 
@@ -35,9 +32,8 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
         1-D array of HEALPix indices
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
 
     Returns
     -------
@@ -55,16 +51,16 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     dx = 0.5
     dy = 0.5
 
-    if order == ORDER_NESTED:
+    if order == 'nested':
         for i in range(n):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
-    elif order == ORDER_RING:
+    elif order == 'ring':
         for i in range(n):
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx, dy, &lon[i], &lat[i])
     else:
-        raise ValueError('order must be 0 or 1')
+      raise ValueError("order must be 'nested' or 'ring'")
 
     return lon, lat
 
@@ -72,7 +68,7 @@ def healpix_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
 def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                                   np.ndarray[double_t, ndim=1, mode="c"] dx,
                                   np.ndarray[double_t, ndim=1, mode="c"] dy,
-                                  int nside, int order):
+                                  int nside, str order):
     """
     Convert HEALPix indices to longitudes/latitudes
 
@@ -89,9 +85,9 @@ def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_
         range [0:1] (0.5 is the center of the HEALPix pixels)
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
+
 
     Returns
     -------
@@ -105,23 +101,23 @@ def healpix_with_offset_to_lonlat(np.ndarray[int64_t, ndim=1, mode="c"] healpix_
     cdef np.ndarray[double_t, ndim=1, mode="c"] lon = np.zeros(n, dtype=npy_double)
     cdef np.ndarray[double_t, ndim=1, mode="c"] lat = np.zeros(n, dtype=npy_double)
 
-    if order == ORDER_NESTED:
+    if order == 'nested':
         for i in range(n):
             xy_index = healpixl_nested_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
-    elif order == ORDER_RING:
+    elif order == 'ring':
         for i in range(n):
             xy_index = healpixl_ring_to_xy(healpix_index[i], nside)
             healpixl_to_radec(xy_index, nside, dx[i], dy[i], &lon[i], &lat[i])
     else:
-        raise ValueError('order must be 0 or 1')
+      raise ValueError("order must be 'nested' or 'ring'")
 
     return lon, lat
 
 
 def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
                       np.ndarray[double_t, ndim=1, mode="c"] lat,
-                      int nside, int order):
+                      int nside, str order):
     """
     Convert longitudes/latitudes to HEALPix indices
 
@@ -134,9 +130,9 @@ def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
         1-D arrays of longitude and latitude in radians
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
+
 
     Returns
     -------
@@ -150,23 +146,23 @@ def lonlat_to_healpix(np.ndarray[double_t, ndim=1, mode="c"] lon,
     cdef double dx, dy;
     cdef np.ndarray[int64_t, ndim=1, mode="c"] healpix_index = np.zeros(n, dtype=npy_int64)
 
-    if order == ORDER_NESTED:
+    if order == 'nested':
         for i in range(n):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_nested(xy_index, nside)
-    elif order == ORDER_RING:
+    elif order == 'ring':
         for i in range(n):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx, &dy)
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
     else:
-        raise ValueError('order must be 0 or 1')
+      raise ValueError("order must be 'nested' or 'ring'")
 
     return healpix_index
 
 
 def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
                                   np.ndarray[double_t, ndim=1, mode="c"] lat,
-                                  int nside, int order):
+                                  int nside, str order):
     """
     Convert longitudes/latitudes to healpix indices
 
@@ -179,9 +175,8 @@ def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
         1-D arrays of longitude and latitude in radians
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
 
     Returns
     -------
@@ -199,16 +194,16 @@ def lonlat_to_healpix_with_offset(np.ndarray[double_t, ndim=1, mode="c"] lon,
     cdef np.ndarray[double_t, ndim=1, mode="c"] dx = np.zeros(n, dtype=npy_double)
     cdef np.ndarray[double_t, ndim=1, mode="c"] dy = np.zeros(n, dtype=npy_double)
 
-    if order == ORDER_NESTED:
+    if order == 'nested':
         for i in range(n):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_nested(xy_index, nside)
-    elif order == ORDER_RING:
+    elif order == 'ring':
         for i in range(n):
             xy_index = radec_to_healpixlf(lon[i], lat[i], nside, &dx[i], &dy[i])
             healpix_index[i] = healpixl_xy_to_ring(xy_index, nside)
     else:
-        raise ValueError('order must be 0 or 1')
+        raise ValueError("order must be 'nested' or 'ring'")
 
     return healpix_index, dx, dy
 
@@ -270,7 +265,7 @@ def ring_to_nested(np.ndarray[int64_t, ndim=1, mode="c"] ring_index, int nside):
 def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
                                 np.ndarray[double_t, ndim=1, mode="c"] lat,
                                 np.ndarray[double_t, ndim=1, mode="c"] values,
-                                int order):
+                                str order):
     """
     Interpolate values at specific longitudes/latitudes using bilinear interpolation
 
@@ -284,9 +279,8 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
         1-D array with the values in each HEALPix pixel. This must have a
         length of the form 12 * nside ** 2 (and nside is determined
         automatically from this).
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
 
     Returns
     -------
@@ -305,6 +299,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
     cdef double_t invalid = np.nan
     cdef intp_t npix = values.shape[0]
     cdef double square_root
+    cdef int order_int
 
     if npix % 12 != 0:
         raise ValueError('Number of pixels must be divisible by 12')
@@ -315,6 +310,13 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
         raise ValueError('Number of pixels is not of the form 12 * nside ** 2')
 
     nside = int(square_root)
+
+    if order == 'nested':
+        order_int = 0
+    elif order == 'ring':
+        order_int = 1
+    else:
+        raise ValueError("order must be 'nested' or 'ring'")
 
     for i in range(n):
 
@@ -367,12 +369,12 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
             result[i] = invalid
             continue
 
-        if order == ORDER_NESTED:
+        if order_int == 0:
             i11 = healpixl_xy_to_nested(i11, nside)
             i12 = healpixl_xy_to_nested(i12, nside)
             i21 = healpixl_xy_to_nested(i21, nside)
             i22 = healpixl_xy_to_nested(i22, nside)
-        elif order == ORDER_RING:
+        elif order_int == 1:
             i11 = healpixl_xy_to_ring(i11, nside)
             i12 = healpixl_xy_to_ring(i12, nside)
             i21 = healpixl_xy_to_ring(i21, nside)
@@ -392,7 +394,7 @@ def interpolate_bilinear_lonlat(np.ndarray[double_t, ndim=1, mode="c"] lon,
 
 
 def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
-                       int nside, int order):
+                       int nside, str order):
     """
     Find all the HEALPix pixels that are the neighbours of a HEALPix pixel
 
@@ -402,9 +404,8 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
         1-D array of HEALPix indices
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
 
     Returns
     -------
@@ -434,7 +435,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     #
     # so we reorder these on-the-fly
 
-    if order == ORDER_NESTED:
+    if order == 'nested':
 
         for i in range(n):
 
@@ -450,7 +451,7 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                 else:
                     neighbours[j, i] = healpixl_xy_to_nested(neighbours_indiv[k], nside)
 
-    elif order == ORDER_RING:
+    elif order == 'ring':
 
         for i in range(n):
 
@@ -468,12 +469,12 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
                     neighbours[j, i] = healpixl_xy_to_ring(neighbours_indiv[k], nside)
 
     else:
-        raise ValueError('order must be 0 or 1')
+        raise ValueError("order must be 'nested' or 'ring'")
 
     return neighbours
 
 
-def healpix_cone_search(double lon, double lat, double radius, int nside, int order, int approx):
+def healpix_cone_search(double lon, double lat, double radius, int nside, str order, int approx):
     """
     Find all the HEALPix pixels that are within a given radius of a longitude/latitude
 
@@ -489,9 +490,8 @@ def healpix_cone_search(double lon, double lat, double radius, int nside, int or
         The search radius, in degrees
     nside : int
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
-    order : int
-        Order of HEALPix pixels. Set this to 0 for nested order or 1 for ring
-        order.
+    order : { 'nested' | 'ring' }
+        Order of HEALPix pixels
     approx : int
         Whether to use an approximation to speed things up. Set to 0 for the
         proper solution, and 1 for an approximate solution.
@@ -510,11 +510,15 @@ def healpix_cone_search(double lon, double lat, double radius, int nside, int or
 
     cdef np.ndarray[int64_t, ndim=1, mode="c"] result = np.zeros(n_indices, dtype=npy_int64)
 
-    for i in range(n_indices):
-        index = indices[i]
-        if order == ORDER_NESTED:
+    if order == 'nested':
+        for i in range(n_indices):
+            index = indices[i]
             result[i] = healpixl_xy_to_nested(index, nside)
-        else:
+    elif order == 'ring':
+        for i in range(n_indices):
+            index = indices[i]
             result[i] = healpixl_xy_to_ring(index, nside)
+    else:
+        raise ValueError("order must be 'nested' or 'ring'")
 
     return result

--- a/healpix/healpy.py
+++ b/healpix/healpy.py
@@ -4,7 +4,7 @@
 This submodule provides a healpy-compatible interface.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 
 import numpy as np
 from astropy import units as u

--- a/healpix/healpy.py
+++ b/healpix/healpy.py
@@ -9,10 +9,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy import units as u
 
-from .core_cython import lonlat_to_healpix, healpix_to_lonlat
 from .core import (nside_to_pixel_resolution, nside_to_pixel_area,
                    nside_to_npix, npix_to_nside, nested_to_ring, ring_to_nested,
-                   level_to_nside)
+                   level_to_nside, lonlat_to_healpix, healpix_to_lonlat)
 
 RAD2DEG = 180 / np.pi
 
@@ -62,18 +61,19 @@ def order2nside(order):
 
 def pix2ang(nside, ipix, nest=False, lonlat=False):
     """Drop-in replacement for healpy `~healpy.pixelfunc.pix2ang`."""
-    ipix = np.atleast_1d(ipix).astype(np.int64, copy=False)
-    lon, lat = healpix_to_lonlat(ipix, nside, 1 - int(nest))
+    lon, lat = healpix_to_lonlat(ipix, nside, order='nested' if nest else 'ring')
     # We use in-place operations below to avoid making temporary arrays - this
     # is safe because the lon/lat arrays returned from healpix_to_lonlat are
     # new and not used elsewhere.
     if lonlat:
-        lon *= RAD2DEG
-        lat *= RAD2DEG
-        return lon, lat
+        return lon.to(u.deg).value, lat.to(u.deg).value
     else:
-        np.subtract(0.5 * np.pi, lat, out=lat)
-        return lat, lon
+        lat, lon = lat.to(u.rad).value, lon.to(u.rad).value
+        if np.isscalar(lon):
+            return 0.5 * np.pi - lat, lon
+        else:
+            lat = np.subtract(0.5 * np.pi, lat, out=lat)
+            return lat, lon
 
 
 def ang2pix(nside, theta, phi, nest=False, lonlat=False):
@@ -81,10 +81,13 @@ def ang2pix(nside, theta, phi, nest=False, lonlat=False):
     # Unlike in pix2ang, we don't use in-place operations since we don't
     # want to modify theta and phi since the user may be using them elsewhere.
     if lonlat:
-        lon, lat = np.atleast_1d(theta) / RAD2DEG, np.atleast_1d(phi) / RAD2DEG
+        lon = np.asarray(theta) / RAD2DEG
+        lat = np.asarray(phi) / RAD2DEG
     else:
-        lat, lon = np.pi / 2. - np.atleast_1d(theta), np.atleast_1d(phi)
-    return lonlat_to_healpix(lon, lat, nside, 1 - int(nest))
+        lat = np.pi / 2. - np.asarray(theta)
+        lon = np.asarray(phi)
+    lon, lat = u.Quantity(lon, u.rad, copy=False), u.Quantity(lat, u.rad, copy=False)
+    return lonlat_to_healpix(lon, lat, nside, order='nested' if nest else 'ring')
 
 
 def nest2ring(nside, ipix):

--- a/healpix/tests/test_core.py
+++ b/healpix/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from itertools import product
 
+import six
 import pytest
 
 import numpy as np
@@ -136,14 +137,14 @@ def test_healpix_to_lonlat_shape():
 def test_lonlat_to_healpix_shape():
 
     healpix_index = lonlat_to_healpix(2 * u.deg, 3 * u.deg, 8)
-    assert isinstance(healpix_index, int)
+    assert isinstance(healpix_index, six.integer_types)
 
     lon, lat = np.ones((2, 4)) * u.deg, np.zeros((2, 4)) * u.deg
     healpix_index = lonlat_to_healpix(lon, lat, 8)
     assert healpix_index.shape == (2, 4)
 
     healpix_index, dx, dy = lonlat_to_healpix(2 * u.deg, 3 * u.deg, 8, return_offsets=True)
-    assert isinstance(healpix_index, int)
+    assert isinstance(healpix_index, six.integer_types)
     assert isinstance(dx, float)
     assert isinstance(dy, float)
 
@@ -158,7 +159,7 @@ def test_lonlat_to_healpix_shape():
 def test_nested_ring_shape(function):
 
     index = function(1, 8)
-    assert isinstance(index, int)
+    assert isinstance(index, six.integer_types)
 
     index = function([[1, 2, 3], [2, 3, 4]], 8)
     assert index.shape == (2, 3)

--- a/healpix/tests/test_core.py
+++ b/healpix/tests/test_core.py
@@ -14,7 +14,7 @@ from ..core import (nside_to_pixel_area, nside_to_pixel_resolution,
                     nside_to_npix, npix_to_nside, healpix_to_lonlat,
                     lonlat_to_healpix, interpolate_bilinear_lonlat,
                     healpix_neighbors, healpix_cone_search, boundaries_lonlat,
-                    level_to_nside)
+                    level_to_nside, nested_to_ring, ring_to_nested)
 
 
 def test_level_to_nside():
@@ -121,6 +121,49 @@ def test_healpix_to_lonlat_invalid():
     assert exc.value.args[0] == 'dy must be in the range [0:1]'
 
 
+def test_healpix_to_lonlat_shape():
+
+    lon, lat = healpix_to_lonlat(2, 8)
+    assert lon.isscalar and lat.isscalar
+
+    lon, lat = healpix_to_lonlat([[1, 2, 3], [3, 4, 4]], 8)
+    assert lon.shape == (2, 3) and lat.shape == (2, 3)
+
+    lon, lat = healpix_to_lonlat([[1], [2], [3]], nside=8, dx=0.2, dy=[[0.1, 0.3]])
+    assert lon.shape == (3, 2) and lat.shape == (3, 2)
+
+
+def test_lonlat_to_healpix_shape():
+
+    healpix_index = lonlat_to_healpix(2 * u.deg, 3 * u.deg, 8)
+    assert isinstance(healpix_index, int)
+
+    lon, lat = np.ones((2, 4)) * u.deg, np.zeros((2, 4)) * u.deg
+    healpix_index = lonlat_to_healpix(lon, lat, 8)
+    assert healpix_index.shape == (2, 4)
+
+    healpix_index, dx, dy = lonlat_to_healpix(2 * u.deg, 3 * u.deg, 8, return_offsets=True)
+    assert isinstance(healpix_index, int)
+    assert isinstance(dx, float)
+    assert isinstance(dy, float)
+
+    lon, lat = np.ones((2, 4)) * u.deg, np.zeros((2, 4)) * u.deg
+    healpix_index, dx, dy = lonlat_to_healpix(lon, lat, 8, return_offsets=True)
+    assert healpix_index.shape == (2, 4)
+    assert dx.shape == (2, 4)
+    assert dy.shape == (2, 4)
+
+
+@pytest.mark.parametrize('function', [nested_to_ring, ring_to_nested])
+def test_nested_ring_shape(function):
+
+    index = function(1, 8)
+    assert isinstance(index, int)
+
+    index = function([[1, 2, 3], [2, 3, 4]], 8)
+    assert index.shape == (2, 3)
+
+
 @pytest.mark.parametrize('order', ['nested', 'ring'])
 def test_interpolate_bilinear_lonlat(order):
     values = np.ones(192) * 3
@@ -141,6 +184,18 @@ def test_interpolate_bilinear_invalid():
         interpolate_bilinear_lonlat([1, 3, 4] * u.deg, [3, 2, 6] * u.deg,
                                     values, order='banana')
     assert exc.value.args[0] == "order must be 'nested' or 'ring'"
+
+
+def test_interpolate_bilinear_lonlat_shape():
+
+    values = np.ones(192) * 3
+
+    result = interpolate_bilinear_lonlat(3 * u.deg, 4 * u.deg, values)
+    assert isinstance(result, float)
+
+    result = interpolate_bilinear_lonlat([[1, 2, 3], [2, 3, 4]] * u.deg,
+                                         [[1, 2, 3], [2, 3, 4]] * u.deg, values)
+    assert result.shape == (2, 3)
 
 
 @pytest.mark.parametrize('order', ['nested', 'ring'])

--- a/healpix/tests/test_core_cython.py
+++ b/healpix/tests/test_core_cython.py
@@ -18,7 +18,7 @@ from .. import core_cython
 
 
 NSIDE_POWERS = range(0, 21)
-ORDERS = (0, 1)
+ORDERS = ('nested', 'ring')
 
 
 def get_test_indices(nside):

--- a/healpix/tests/test_healpy.py
+++ b/healpix/tests/test_healpy.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from itertools import product
 
+import six
+
 import pytest
 import numpy as np
 
@@ -69,6 +71,26 @@ def test_ang2pix(nside_pow, lon, lat, nest, lonlat):
     ipix1 = hp_compat.ang2pix(nside, theta, phi, nest=nest, lonlat=lonlat)
     ipix2 = hp.ang2pix(nside, theta, phi, nest=nest, lonlat=lonlat)
     assert ipix1 == ipix2
+
+
+def test_ang2pix_shape():
+
+    ipix = hp_compat.ang2pix(8, 1., 2.)
+    assert isinstance(ipix, six.integer_types)
+
+    ipix = hp_compat.ang2pix(8, [[1., 2.], [3., 4.]], [[1., 2.], [3., 4.]])
+    assert ipix.shape == (2, 2)
+
+
+def test_pix2ang_shape():
+
+    lon, lat = hp_compat.pix2ang(8, 1)
+    assert isinstance(lon, float)
+    assert isinstance(lat, float)
+
+    lon, lat = hp_compat.pix2ang(8, [[1, 2, 3], [4, 5, 6]])
+    assert lon.shape == (2, 3)
+    assert lat.shape == (2, 3)
 
 
 @given(nside_pow=integers(0, 29), nest=booleans(), lonlat=booleans(),

--- a/healpix/tests/test_healpy.py
+++ b/healpix/tests/test_healpy.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 
 from itertools import product
 

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     scripts=scripts,
-    install_requires=['numpy', 'astropy'],
+    install_requires=['numpy', 'astropy', 'six'],
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
     license=LICENSE,


### PR DESCRIPTION
@cdeil - I had a bit of time so worked on this. I have not done anything for the functions that get neighbours or boundaries since those already return 2D arrays, so I thought it might be confusing if we return e.g. an (8, 3, 2) array (where 8 is the number of neighbours). What do you think?

Fixes https://github.com/cdeil/healpix/issues/21