### PR TITLE
Remove approximate mode from cone search and clarify docstrings

### DIFF
--- a/healpix/core.py
+++ b/healpix/core.py
@@ -414,13 +414,14 @@ def healpix_neighbors(healpix_index, nside, order='ring'):
     return core_cython.healpix_neighbors(healpix_index, nside, order)
 
 
-def healpix_cone_search(lon, lat, radius, nside, order='ring', approximate=False):
+def healpix_cone_search(lon, lat, radius, nside, order='ring'):
     """
-    Find all the HEALPix pixels that are within a given radius of a longitude/latitude
+    Find all the HEALPix pixels within a given radius of a longitude/latitude.
 
-    Note that this function can only be used for a single lon/lat pair at a
-    time, since different calls to the function may result in a different number
-    of matches.
+    Note that this returns all pixels that overlap, including partially, with
+    the search cone. This function can only be used for a single lon/lat pair at
+    a time, since different calls to the function may result in a different
+    number of matches.
 
     Parameters
     ----------
@@ -432,8 +433,6 @@ def healpix_cone_search(lon, lat, radius, nside, order='ring', approximate=False
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
     order : { 'nested' | 'ring' }
         Order of HEALPix pixels
-    approximate : bool
-        Whether to use an approximation to speed things up.
 
     Returns
     -------
@@ -445,12 +444,11 @@ def healpix_cone_search(lon, lat, radius, nside, order='ring', approximate=False
     lat = float(lat.to(u.deg).value)
     radius = float(radius.to(u.deg).value)
     nside = int(nside)
-    approximate = int(approximate)
 
     _validate_nside(nside)
     order = _validate_order(order)
 
-    return core_cython.healpix_cone_search(lon, lat, radius, nside, order, approximate)
+    return core_cython.healpix_cone_search(lon, lat, radius, nside, order)
 
 
 def boundaries_lonlat(healpix_index, step, nside, order='ring'):

--- a/healpix/core_cython.pyx
+++ b/healpix/core_cython.pyx
@@ -485,13 +485,14 @@ def healpix_neighbors(np.ndarray[int64_t, ndim=1, mode="c"] healpix_index,
     return neighbours
 
 
-def healpix_cone_search(double lon, double lat, double radius, int nside, str order, int approx):
+def healpix_cone_search(double lon, double lat, double radius, int nside, str order):
     """
-    Find all the HEALPix pixels that are within a given radius of a longitude/latitude
+    Find all the HEALPix pixels within a given radius of a longitude/latitude.
 
-    Note that this function can only be used for a single lon/lat pair at a
-    time, since different calls to the function may result in a different number
-    of matches.
+    Note that this returns all pixels that overlap, including partially, with
+    the search cone. This function can only be used for a single lon/lat pair at
+    a time, since different calls to the function may result in a different
+    number of matches.
 
     Parameters
     ----------
@@ -503,9 +504,6 @@ def healpix_cone_search(double lon, double lat, double radius, int nside, str or
         Number of pixels along the side of each of the 12 top-level HEALPix tiles
     order : { 'nested' | 'ring' }
         Order of HEALPix pixels
-    approx : int
-        Whether to use an approximation to speed things up. Set to 0 for the
-        proper solution, and 1 for an approximate solution.
 
     Returns
     -------
@@ -517,7 +515,7 @@ def healpix_cone_search(double lon, double lat, double radius, int nside, str or
     cdef int64_t n_indices
     cdef int64_t index
 
-    n_indices =  healpix_rangesearch_radec_simple(lon, lat, radius, nside, approx, &indices)
+    n_indices =  healpix_rangesearch_radec_simple(lon, lat, radius, nside, 0, &indices)
 
     cdef np.ndarray[int64_t, ndim=1, mode="c"] result = np.zeros(n_indices, dtype=npy_int64)
 

--- a/healpix/high_level.py
+++ b/healpix/high_level.py
@@ -155,13 +155,13 @@ class HEALPix(object):
             raise ValueError('values must be an array of length {0} (got {1})'.format(self.npix, len(values)))
         return interpolate_bilinear_lonlat(lon, lat, values, order=self.order)
 
-    def cone_search_lonlat(self, lon, lat, radius, approximate=False):
+    def cone_search_lonlat(self, lon, lat, radius):
         """
-        Find all the HEALPix pixels that are within a given radius of a
-        longitude/latitude.
+        Find all the HEALPix pixels within a given radius of a longitude/latitude.
 
-        Note that this function can only be used for a single lon/lat pair at a
-        time, since different calls to the function may result in a different
+        Note that this returns all pixels that overlap, including partially, with
+        the search cone. This function can only be used for a single lon/lat pair at
+        a time, since different calls to the function may result in a different
         number of matches.
 
         Parameters
@@ -170,8 +170,6 @@ class HEALPix(object):
             The longitude and latitude to search around
         radius : :class:`~astropy.units.Quantity`
             The search radius
-        approximate : bool
-            Whether to use an approximation to speed things up.
 
         Returns
         -------
@@ -181,8 +179,7 @@ class HEALPix(object):
         if not lon.isscalar or not lat.isscalar or not radius.isscalar:
             raise ValueError('The longitude, latitude and radius must be '
                              'scalar Quantity objects')
-        return healpix_cone_search(lon, lat, radius, self.nside,
-                                   order=self.order, approximate=approximate)
+        return healpix_cone_search(lon, lat, radius, self.nside, order=self.order)
 
     def boundaries_lonlat(self, healpix_index, step):
         """
@@ -302,14 +299,14 @@ class CelestialHEALPix(HEALPix):
         lon, lat = representation.lon, representation.lat
         return self.interpolate_bilinear_lonlat(lon, lat, values)
 
-    def cone_search_skycoord(self, skycoord, radius, approximate=False):
+    def cone_search_skycoord(self, skycoord, radius):
         """
-        Find all the HEALPix pixels that are within a given radius of a
-        celestial position.
+        Find all the HEALPix pixels within a given radius of a celestial position.
 
-        Note that this function can only be used for a single celestial position
-        at a time, since different calls to the function may result in a
-        different number of matches.
+        Note that this returns all pixels that overlap, including partially,
+        with the search cone. This function can only be used for a single
+        celestial position at a time, since different calls to the function may
+        result in a different number of matches.
 
         Parameters
         ----------
@@ -317,8 +314,6 @@ class CelestialHEALPix(HEALPix):
             The celestial coordinates to use for the cone search
         radius : :class:`~astropy.units.Quantity`
             The search radius
-        approximate : bool
-            Whether to use an approximation to speed things up.
 
         Returns
         -------
@@ -328,7 +323,7 @@ class CelestialHEALPix(HEALPix):
         skycoord = skycoord.transform_to(self.frame)
         representation = skycoord.represent_as(UnitSphericalRepresentation)
         lon, lat = representation.lon, representation.lat
-        return self.cone_search_lonlat(lon, lat, radius, approximate=approximate)
+        return self.cone_search_lonlat(lon, lat, radius)
 
     def boundaries_skycoord(self, healpix_index, step):
         """

--- a/healpix/tests/test_core_cython.py
+++ b/healpix/tests/test_core_cython.py
@@ -89,7 +89,7 @@ def test_healpix_cone_search(order, nside_power, capfd):
     nside = 2 ** nside_power
     lon0, lat0 = 12., 40.
     radius = nside_to_pixel_resolution(nside).to(u.degree).value * 10
-    index_inside = core_cython.healpix_cone_search(lon0, lat0, radius, nside, order, 0)
+    index_inside = core_cython.healpix_cone_search(lon0, lat0, radius, nside, order)
     n_inside = len(index_inside)
     dx = np.array([[0.0, 0.0, 1.0, 1.0]])
     dy = np.array([[0.0, 1.0, 1.0, 0.0]])


### PR DESCRIPTION
During investigations in https://github.com/cdeil/healpix/issues/41 I found that the approximate mode produces strange results, so I don't think we should expose it through the API. We could in future implement a mode equivalent to the one in healpy that uses just the center of the pixels, but that can be done without the C code.