### PR TITLE
Do the six ourselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ healpix/core_cython.c
 v
 
 .hypothesis
+.eggs

--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,8 +16,6 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python -c 'import sys; print(sys.maxsize)'
 
-pip install six
-
 # We only test the docs output on 64-bit Linux so as not to have to 
 # degrade the output with ellipses to work on all platforms.
 python setup.py test -V -a "-s" --skip-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython healpy>1.10 hypothesis six'
+        - CONDA_DEPENDENCIES='Cython healpy>1.10 hypothesis'
 
         # Conda packages for affiliated packages are hosted in channel
         # "astropy" while builds for astropy LTS with recent numpy versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
 
-      CONDA_DEPENDENCIES: "Cython numpy six"
+      CONDA_DEPENDENCIES: "Cython numpy"
 
   matrix:
 

--- a/healpix/tests/six.py
+++ b/healpix/tests/six.py
@@ -1,0 +1,16 @@
+"""Python 2 / 3 compatibility helpers.
+
+Usually we would import and depend on
+https://github.com/benjaminp/six/blob/master/six.py
+but since in this package we need so little,
+we just copied the few lines over from there
+"""
+import sys
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+
+if PY3:
+    integer_types = int,
+else:
+    integer_types = (int, long)

--- a/healpix/tests/test_core.py
+++ b/healpix/tests/test_core.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from itertools import product
 
-import six
+from .six import integer_types
 import pytest
 
 import numpy as np
@@ -137,14 +137,14 @@ def test_healpix_to_lonlat_shape():
 def test_lonlat_to_healpix_shape():
 
     healpix_index = lonlat_to_healpix(2 * u.deg, 3 * u.deg, 8)
-    assert isinstance(healpix_index, six.integer_types)
+    assert isinstance(healpix_index, integer_types)
 
     lon, lat = np.ones((2, 4)) * u.deg, np.zeros((2, 4)) * u.deg
     healpix_index = lonlat_to_healpix(lon, lat, 8)
     assert healpix_index.shape == (2, 4)
 
     healpix_index, dx, dy = lonlat_to_healpix(2 * u.deg, 3 * u.deg, 8, return_offsets=True)
-    assert isinstance(healpix_index, six.integer_types)
+    assert isinstance(healpix_index, integer_types)
     assert isinstance(dx, float)
     assert isinstance(dy, float)
 
@@ -159,7 +159,7 @@ def test_lonlat_to_healpix_shape():
 def test_nested_ring_shape(function):
 
     index = function(1, 8)
-    assert isinstance(index, six.integer_types)
+    assert isinstance(index, integer_types)
 
     index = function([[1, 2, 3], [2, 3, 4]], 8)
     assert index.shape == (2, 3)

--- a/healpix/tests/test_healpy.py
+++ b/healpix/tests/test_healpy.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 from itertools import product
 
-import six
+from .six import integer_types
 
 import pytest
 import numpy as np
@@ -77,7 +77,7 @@ def test_ang2pix(nside_pow, lon, lat, nest, lonlat):
 def test_ang2pix_shape():
 
     ipix = hp_compat.ang2pix(8, 1., 2.)
-    assert isinstance(ipix, six.integer_types)
+    assert isinstance(ipix, integer_types)
 
     ipix = hp_compat.ang2pix(8, [[1., 2.], [3., 4.]], [[1., 2.], [3., 4.]])
     assert ipix.shape == (2, 2)

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     scripts=scripts,
-    install_requires=['numpy', 'astropy', 'six'],
+    install_requires=['numpy', 'astropy'],
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
     license=LICENSE,


### PR DESCRIPTION
While updating the install page in #47 I noticed that to be complete we should mention the dependency on six. But then I looked and all we need in `integer_types` in the tests. So I'd suggest to just avoid the dependency -> this PR.

@astrofrog - thoughts?