### PR TITLE
Add initial version of healpix/bench.py

### DIFF
--- a/healpix/bench.py
+++ b/healpix/bench.py
@@ -76,7 +76,7 @@ def bench_run():
                 time_healpy = bench_pix2ang(size=size, nside=nside, nest=nest, package='healpy')
 
                 results.append(dict(
-                    fct='pix2ang', size=size, nside=nside,
+                    fct='pix2ang', size=int(size), nside=nside,
                     time_self=time_self, time_healpy=time_healpy,
                 ))
 
@@ -87,6 +87,11 @@ def bench_report(results):
     """Print a report for given benchmark results to the console."""
     table = Table(rows=results)
     table['ratio'] = table['time_self'] / table['time_healpy']
+
+    table['time_self'].format = '10.7f'
+    table['time_healpy'].format = '10.7f'
+    table['ratio'].format = '7.2f'
+
     table.pprint(max_lines=-1)
 
 

--- a/healpix/bench.py
+++ b/healpix/bench.py
@@ -1,0 +1,102 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Benchmarks for this package.
+
+To run all benchmarks and print a report to the console::
+
+    python -m healpix.bench
+
+You can also run the benchmarks first, save the results dict
+to disk as a JSON file (or share it with others) and then
+print the results later, or compare them with other results.
+
+We should now that this is not very comprehensive / flexible.
+
+If your application depends on performance of HEALPix computations,
+you should write benchmarks with cases relevant for that application
+and check if HEALPix computations are really the bottleneck and if
+this package is fast enough for you or not.
+"""
+from textwrap import dedent
+import timeit
+from astropy.table import Table
+import healpy as hp
+from . import healpy as hp_compat
+
+
+# Copied from https://github.com/kwgoodman/bottleneck/blob/master/bottleneck/benchmark/autotimeit.py
+def autotimeit(stmt, setup='pass', repeat=3, mintime=0.2):
+    timer = timeit.Timer(stmt, setup)
+    number, time1 = autoscaler(timer, mintime)
+    time2 = timer.repeat(repeat=repeat - 1, number=number)
+    return min(time2 + [time1]) / number
+
+
+# Copied from https://github.com/kwgoodman/bottleneck/blob/master/bottleneck/benchmark/autotimeit.py
+def autoscaler(timer, mintime):
+    number = 1
+    for i in range(12):
+        time = timer.timeit(number)
+        if time > mintime:
+            return number, time
+        number *= 10
+    raise RuntimeError('function is too fast to test')
+
+
+def get_import(package, fct):
+    if package == 'self':
+        return 'from healpix.healpy import {}'.format(fct)
+    else:
+        return 'from healpy import {}'.format(fct)
+
+
+def bench_pix2ang(size, nside, nest, package):
+    shape = (int(size), )
+
+    setup = '\n'.join([
+        get_import(package, 'pix2ang'),
+        'import numpy as np',
+        'nside={}'.format(int(nside)),
+        'ipix=np.zeros({}, dtype=np.int64)'.format(shape),
+        'nest={}'.format(nest),
+    ])
+
+    stmt = 'pix2ang(nside, ipix, nest)'
+
+    return autotimeit(stmt=stmt, setup=setup, repeat=1, mintime=0.1)
+
+
+def bench_run():
+    """Run all benchmarks. Return results as a dict."""
+    results = []
+
+    for nest in [True, False]:
+        for size in [10, 1e3, 1e6]:
+            for nside in [1, 128]:
+                time_self = bench_pix2ang(size=size, nside=nside, nest=nest, package='self')
+                time_healpy = bench_pix2ang(size=size, nside=nside, nest=nest, package='healpy')
+
+                results.append(dict(
+                    fct='pix2ang', size=size, nside=nside,
+                    time_self=time_self, time_healpy=time_healpy,
+                ))
+
+    return results
+
+
+def bench_report(results):
+    """Print a report for given benchmark results to the console."""
+    table = Table(rows=results)
+    table['ratio'] = table['time_self'] / table['time_healpy']
+    table.pprint(max_lines=-1)
+
+
+def main():
+    """Run all benchmarks and print report to the console."""
+    print('Running benchmarks ...\n')
+    results = bench_run()
+    print('Printint benchmark report ...\n')
+    bench_report(results)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@astrofrog - Here's a first version version of the simple benchmark tool I was suggesting we add in #22 . I don't have much time to work on it, i.e. to implement a good set of benchmarks / discuss the most useful / common ranges of parameters. Note that this is not mentioned in the docs at the moment, so it doesn't hurt to add this and continue with this at a later time.

But of course, I can improve what's here a bit, so @astrofrog - please review.

This is what I get: our `pix2ang` is 3 to 30 times slower than healpy:
```
$ python -m healpix.bench

  fct   nside    size      time_healpy        time_self         ratio    
------- ----- --------- ----------------- ----------------- -------------
pix2ang     1      10.0 1.64522665087e-05 0.000443432048894 26.9526419755
pix2ang   128      10.0 1.71232097782e-05 0.000473170915153 27.6333071475
pix2ang     1    1000.0 6.88082155306e-05 0.000629744681064 9.15217283587
pix2ang   128    1000.0 5.89831649791e-05 0.000646529261954   10.96125076
pix2ang     1 1000000.0    0.046561223967    0.186104812194 3.99699140911
pix2ang   128 1000000.0   0.0430329156108    0.168343361001 3.91196735364
pix2ang     1      10.0 1.79602983873e-05 0.000469027797226 26.1146996064
pix2ang   128      10.0 1.78020515013e-05 0.000435932659078 24.4877765377
pix2ang     1    1000.0 6.23817889951e-05 0.000627744712867 10.0629482254
pix2ang   128    1000.0 7.60771340691e-05 0.000690915605985 9.08177752013
pix2ang     1 1000000.0   0.0432159634773    0.177236157004 4.10117333372
pix2ang   128 1000000.0    0.059067048179    0.208908177912  3.5367973236
```
At least for the applications I'm working on (gammapy, hips), this is fast enough, speed in healpix doesn't matter, only the functionality is needed.